### PR TITLE
docs(claude): add branch-only commit rule

### DIFF
--- a/dot_claude/CLAUDE.md
+++ b/dot_claude/CLAUDE.md
@@ -4,3 +4,4 @@
 - Follow [Conventional Commits](https://www.conventionalcommits.org/) format: `<type>(<scope>): <description>`. Common types: `feat`, `fix`, `docs`, `style`, `refactor`, `test`, `chore`, `ci`, `perf`, `build`.
 - Only add `Co-Authored-By` trailer when Claude has edited files in the commit. Do not add it when Claude only creates the commit message. Use the actual model name powering the current session (e.g., `Co-Authored-By: Claude <model> <noreply@anthropic.com>`).
 - When Claude has edited files, include the user's original prompt (the instruction that led to the changes) in the commit message body under a `Prompt:` section.
+- Never commit directly to main/master. Always create a feature branch and commit there.


### PR DESCRIPTION
## Summary
- CLAUDE.md に main/master への直接コミットを禁止し、必ずフィーチャーブランチを作成するルールを追加

## Test plan
- [ ] CLAUDE.md の内容が正しく反映されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)